### PR TITLE
Only upload docs when running Rust nightly

### DIFF
--- a/travis-doc-upload.sh
+++ b/travis-doc-upload.sh
@@ -7,6 +7,8 @@ set -e
 
 . ./scripts/travis-doc-upload.cfg
 
+[ "$TRAVIS_RUST_VERSION" = "nightly" ]
+
 [ "$TRAVIS_BRANCH" = master ]
 
 [ "$TRAVIS_PULL_REQUEST" = false ]


### PR DESCRIPTION
This will avoid duplicate uploads when Travis-CI runs with multiple Rust version like in https://github.com/servo/tendril/pull/14
